### PR TITLE
Remove Jenkins test harness from hpi file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,13 +88,6 @@
 			<version>1.23</version>
 		</dependency>
 
-		<dependency>
-			<groupId>org.jenkins-ci.main</groupId>
-			<artifactId>jenkins-test-harness</artifactId>
-			<version>1802.v9de0d87365d2</version>
-		</dependency>
-
-
     </dependencies>
     <build>
     	<pluginManagement>


### PR DESCRIPTION
## Remove Jenkins test harness from the plugin hpi file

https://github.com/jenkinsci/jenkins/pull/8714 included in Jenkins 2.434 and later will refuse to load a plugin that includes the Jenkins test harness.

The Jenkins test harness causes unexpected failures when it is included in a Jenkins plugin.  Refer to the following issue reports for examples:

* https://issues.jenkins.io/browse/JENKINS-65650
* https://issues.jenkins.io/browse/JENKINS-66060
* https://issues.jenkins.io/browse/JENKINS-72353

The additional benefit of the change is that it makes the plugin hpi file over 90% smaller.

Before this change, the plugin hpi file had the following contents:

```
 61162 BuildStepController.js
 41450 DlistActions.js
 40183 images/bmc_build_step.jpg
374726 images/dlp_plugin.jpg
 33108 images/plugin_version.jpg
 42957 images/workspace.jpg
   737 META-INF/MANIFEST.MF
    81 META-INF/maven/com.bmc.ims/bmc-change-manager-imstm/pom.properties
  4254 META-INF/maven/com.bmc.ims/bmc-change-manager-imstm/pom.xml
 81188 WEB-INF/lib/bmc-change-manager-imstm.jar
1692782 WEB-INF/lib/commons-math3-3.2.jar
307305 WEB-INF/lib/commons-net-3.8.0.jar
 98115 WEB-INF/lib/dec-0.1.2.jar
160975 WEB-INF/lib/embedded-rhino-debugger-1.2.jar
123360 WEB-INF/lib/hamcrest-2.2.jar
  1499 WEB-INF/lib/hamcrest-core-2.2.jar
  1537 WEB-INF/lib/hamcrest-library-2.2.jar
 56674 WEB-INF/lib/javax.activation-api-1.2.0.jar
128032 WEB-INF/lib/jaxb-api-2.4.0-b180830.0359.jar
426248 WEB-INF/lib/jenkins-test-harness-1802.v9de0d87365d2.jar
10958672 WEB-INF/lib/jenkins-test-harness-htmlunit-106.vc41185ea_3d3d.jar
325897 WEB-INF/lib/jetty-client-9.4.48.v20220622.jar
234754 WEB-INF/lib/jetty-http-9.4.48.v20220622.jar
183018 WEB-INF/lib/jetty-io-9.4.48.v20220622.jar
118511 WEB-INF/lib/jetty-security-9.4.48.v20220622.jar
732200 WEB-INF/lib/jetty-server-9.4.48.v20220622.jar
146081 WEB-INF/lib/jetty-servlet-9.4.48.v20220622.jar
582975 WEB-INF/lib/jetty-util-9.4.48.v20220622.jar
 66654 WEB-INF/lib/jetty-util-ajax-9.4.48.v20220622.jar
140320 WEB-INF/lib/jetty-webapp-9.4.48.v20220622.jar
 68301 WEB-INF/lib/jetty-xml-9.4.48.v20220622.jar
541449 WEB-INF/lib/jmh-core-1.35.jar
 31277 WEB-INF/lib/jmh-generator-annprocess-1.35.jar
 78146 WEB-INF/lib/jopt-simple-5.0.4.jar
 65966 WEB-INF/lib/json-20200518.jar
187400 WEB-INF/lib/org-netbeans-insane-RELEASE140.jar
 65728 WEB-INF/lib/salvation2-3.0.0.jar
  6884 WEB-INF/lib/support-log-formatter-1.1.jar
  2699 WEB-INF/lib/symbol-annotation-1.23.jar
 52173 WEB-INF/lib/websocket-api-9.4.48.v20220622.jar
 45622 WEB-INF/lib/websocket-client-9.4.48.v20220622.jar
214632 WEB-INF/lib/websocket-common-9.4.48.v20220622.jar
 45510 WEB-INF/lib/websocket-server-9.4.48.v20220622.jar
 30315 WEB-INF/lib/websocket-servlet-9.4.48.v20220622.jar
 15495 WEB-INF/licenses.xml
```

After this change, the plugin hpi file has the following contents:

```
 61162 BuildStepController.js
 41450 DlistActions.js
 40183 images/bmc_build_step.jpg
374726 images/dlp_plugin.jpg
 33108 images/plugin_version.jpg
 42957 images/workspace.jpg
   767 META-INF/MANIFEST.MF
    80 META-INF/maven/com.bmc.ims/bmc-change-manager-imstm/pom.properties
  4048 META-INF/maven/com.bmc.ims/bmc-change-manager-imstm/pom.xml
 81282 WEB-INF/lib/bmc-change-manager-imstm.jar
 56674 WEB-INF/lib/javax.activation-api-1.2.0.jar
128032 WEB-INF/lib/jaxb-api-2.4.0-b180830.0359.jar
 65966 WEB-INF/lib/json-20200518.jar
  2699 WEB-INF/lib/symbol-annotation-1.23.jar
  2466 WEB-INF/licenses.xml
```

### Testing done

Confirmed automated tests pass.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
