### PR TITLE
Use `jenkins.baseline` to reduce bom update mistakes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,12 +14,13 @@
     <properties>
         <!-- revision>1.0</revision-->
         <!-- changelist>-SNAPSHOT</changelist-->
-        <!--jenkins.version>2.277.1</jenkins.version-->
-		<changelist>999999-SNAPSHOT</changelist>
-		<jenkins.version>2.346.2</jenkins.version>
+        <changelist>999999-SNAPSHOT</changelist>
+        <!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+        <jenkins.baseline>2.346</jenkins.baseline>
+        <jenkins.version>${jenkins.baseline}.2</jenkins.version>
         <java.level>11</java.level>
-		<gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
-            </properties>
+        <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
+    </properties>
     <name>BMC AMI DevOps for Change Manager for IMS TM</name>
     <description>BMC DevOps for AMI Change Manager for IMS TM provides the capability of manipulating IMS resources online.</description>
 
@@ -41,7 +42,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.277.x</artifactId>
+                <artifactId>bom-${jenkins.baseline}.x</artifactId>
                 <version>26</version>
                 <scope>import</scope>
                 <type>pom</type>


### PR DESCRIPTION
## Use `jenkins.baseline` in `pom.xml`

This change is proposed by the plugin archetype and makes maintenance of `jenkins.version` and `bom` a little easier.

### Testing done

None. Rely on `ci.jenkins.io` to test it.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
