### PR TITLE
Fix ci.jenkins.io build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 	</licenses>
 
 	<scm>
-		<connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
+		<connection>scm:git:https://github.com/${gitHubRepo}.git</connection>
 		<developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
 		<tag>bmc-change-manager-imstm-1.0.01</tag>
 		<url>https://github.com/${gitHubRepo}</url>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,6 @@
         <!--jenkins.version>2.277.1</jenkins.version-->
 		<changelist>999999-SNAPSHOT</changelist>
 		<jenkins.version>2.346.2</jenkins.version>
-        <java.level>11</java.level>
 		<gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
             </properties>
     <name>BMC AMI DevOps for Change Manager for IMS TM</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.8</version>
+        <version>4.43.1</version>
         <relativePath />
     </parent>
     <groupId>com.bmc.ims</groupId>
@@ -16,8 +16,8 @@
         <!-- changelist>-SNAPSHOT</changelist-->
         <!--jenkins.version>2.277.1</jenkins.version-->
 		<changelist>999999-SNAPSHOT</changelist>
-		<jenkins.version>2.492.3</jenkins.version>
-        <!--java.level>11</java.level-->
+		<jenkins.version>2.346.2</jenkins.version>
+        <java.level>11</java.level>
 		<gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
             </properties>
     <name>BMC AMI DevOps for Change Manager for IMS TM</name>
@@ -31,7 +31,7 @@
 	</licenses>
 
 	<scm>
-		<connection>scm:git:https://github.com/${gitHubRepo}.git</connection>		
+		<connection>scm:git:git://github.com/${gitHubRepo}.git</connection>
 		<developerConnection>scm:git:git@github.com:${gitHubRepo}.git</developerConnection>
 		<tag>bmc-change-manager-imstm-1.0.01</tag>
 		<url>https://github.com/${gitHubRepo}</url>
@@ -40,9 +40,9 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>io.jenkins.tools.bom</groupId>            
-	        <artifactId>bom-2.479.x</artifactId>               
-       	        <version>4948.vcf1d17350668</version>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.277.x</artifactId>
+                <version>26</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -88,28 +88,5 @@
 		</dependency>
 
     </dependencies>
-    <build>
-    	<pluginManagement>
-    		<plugins>
 
-    			
-    			 <plugin>
-
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-surefire-plugin</artifactId>
-					<version>3.0.0-M3</version>
-					<configuration>
-						<excludes>
-						<!--exclude>**/InjectedTest*.*</exclude-->
-						
-						</excludes>
-			
-					</configuration>
-			
-				</plugin>
-    		</plugins>
-    	</pluginManagement>
-    </build>
-    
-   
 </project>


### PR DESCRIPTION
## Fix ci.jenkins.io build

* Revert "Update pom.xml" 97040b9c773b9184a01414171ba40ed19570419d .
  Repair the ci.jenkins.io build by removing recent breaking changes
* Remove duplicated surefire definition.
  Provided by the parent pom
* Remove unnecessary declaration of java.level.
  The plugin pom file provides the correct value for java.level without the plugin maintainer tracking it.
* Use https instead of git protocol for source connection
  GitHub [dropped git protocol support](https://github.blog/security/application-security/improving-git-protocol-security-github/) years ago

### Testing done

Confirmed that `mvn clean verify` passes locally with Java 8.  Rely on ci.jenkins.io to confirm the same.

Confirmed that the hpi file from the build does not include the Jenkins test harness.

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
