### PR TITLE
Replace json dependency with json API plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,9 +66,8 @@
 
 
 		<dependency>
-    		<groupId>org.json</groupId>
-    		<artifactId>json</artifactId>
-    		<version>20200518</version>
+		<groupId>io.jenkins.plugins</groupId>
+		<artifactId>json-api</artifactId>
     	</dependency>
 		<dependency>
 			<groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
## Replace json dependency with json API plugin

Use JSON API plugin instead of bundling the JSON API jar file in the Jenkins plugin binary.

From
https://www.jenkins.io/doc/developer/plugin-development/dependencies-and-class-loading/#using-library-wrapper-plugins

In practice it is undesirable for Jenkins feature plugins to bundle
assorted third-party libraries. Typically other plugins will need
some of the same libraries, so multiple plugins will wind up bundling
copies. Even if all of these copies happen to be the exact same version,
“downstream” plugins can wind up getting linkage errors. And users
will wind up downloading multiple copies of the same code, increasing
product and $JENKINS_HOME/plugins/ sizes, update center load, HotSpot
compiler delays, etc.

### Testing done

Confirmed that `mvn clean verify` passes

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
